### PR TITLE
don't overwrite correct letters as misplased

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -24,7 +24,7 @@ impl Keyboard {
         if let Some(m) = self
             .0
             .iter_mut()
-            .find_map(|(c, m)| (*c == letter).then_some(m))
+            .find_map(|(c, m)| (*c == letter && !matches!(m, Some(Match::Correct))).then_some(m))
         {
             *m = Some(mark);
         }


### PR DESCRIPTION
if the letter is used in some incorrect place after its correct place was already established, it overwrites its color to yellow.

prevent that by skipping correct letters in `mark_letter`